### PR TITLE
Remove needless semicolons following enum.

### DIFF
--- a/Basic-Types.md
+++ b/Basic-Types.md
@@ -46,28 +46,28 @@ var list:Array<number> = [1, 2, 3];
 A helpful addition to the standard set of datatypes from JavaScript is the 'enum'.  Like languages like C#, an enum is a way of giving more friendly names to sets of numeric values. 
 
 ```TypeScript
-enum Color {Red, Green, Blue};
+enum Color {Red, Green, Blue}
 var c: Color = Color.Green;
 ```
 
 By default, enums begin numbering their members starting at 0.  You can change this by manually setting the value of one its members.  For example, we can start the previous example at 1 instead of 0:
 
 ```TypeScript
-enum Color {Red = 1, Green, Blue};
+enum Color {Red = 1, Green, Blue}
 var c: Color = Color.Green;
 ```
 
 Or, even manually set all the values in the enum:
 
 ```TypeScript
-enum Color {Red = 1, Green = 2, Blue = 4};
+enum Color {Red = 1, Green = 2, Blue = 4}
 var c: Color = Color.Green;
 ```
 
 A handy feature of enums is that you can also go from a numeric value to the name of that value in the enum.  For example, if we had the value 2 but weren't sure which that mapped to in the Color enum above, we could look up the corresponding name:
 
 ```TypeScript
-enum Color {Red = 1, Green, Blue};
+enum Color {Red = 1, Green, Blue}
 var colorName: string = Color[2];
 
 alert(colorName);

--- a/Type-Compatibility.md
+++ b/Type-Compatibility.md
@@ -146,8 +146,8 @@ When a function has overloads, each overload in the source type must be matched 
 Enums are compatible with numbers, and numbers are compatible with enums.  Enum values from different enum types are considered incompatible.  For example,
 
 ```TypeScript
-enum Status { Ready, Waiting };
-enum Color { Red, Blue, Green };
+enum Status { Ready, Waiting }
+enum Color { Red, Blue, Green }
 
 var status = Status.Ready;
 status = Color.Green;  //error


### PR DESCRIPTION
This pull-request unifies usage of semicolon in examples of enum. Enum doesn't need a semicolon, but some examples have them.

These semicolons make the readers think that a semicolon is required after enum. Such question was actually posted to TypeScripst's repository:
> [Const enum leaves behind semicolons · Issue #1685 · Microsoft/TypeScript](https://github.com/Microsoft/TypeScript/issues/1685)