### PR TITLE
Fix inline code tag

### DIFF
--- a/API-Breaking-Changes.md
+++ b/API-Breaking-Changes.md
@@ -40,8 +40,8 @@
 ### All usages of 'filename' and 'Filename' changed to 'fileName' and 'FileName'
 Here are the details:
 - `CompilerHost.getDefaultLibFilename` => `CompilerHost.getDefaultLibFileName`
-- `SourceFile .filename` => `SourceFile.fileName`
-- `FileReference`.filename => `FileReference.fileName`
+- `SourceFile.filename` => `SourceFile.fileName`
+- `FileReference.filename` => `FileReference.fileName`
 - `LanguageServiceHost.getDefaultLibFilename` => `LanguageServiceHost.getDefaultLibFileName`
 - `LanguageServiceShimHost.getDefaultLibFilename` => `LanguageServiceShimHost.getDefaultLibFileName`
 


### PR DESCRIPTION
Fixing a typo concerning the inline code tag in the wiki; see diff.