### PR TITLE
Improve documentation for exclude

### DIFF
--- a/tsconfig.json.md
+++ b/tsconfig.json.md
@@ -57,12 +57,12 @@ Example `tsconfig.json` files:
 }
 ```
 
-## Details 
+## Details
 The `"compilerOptions"` property can be omitted, in which case the compiler's defaults are used. See our full list of supported [[Compiler Options]].
 
-If no `"files"` property is present in a `tsconfig.json`, the compiler defaults to including all files in the containing directory and subdirectories. When a `"files"` property is specified, only those files are included.
+If no `"files"` property is present in a `tsconfig.json`, the compiler defaults to including all TypeScript (\*.ts or \*.tsx) files in the containing directory and subdirectories. When a `"files"` property is present, only the specified files are included.
 
-If the `"exclude"` property is specified, the compiler includes all files in the containing directory and subdirectories except for those files that are excluded.
+If the `"exclude"` property is specified, the compiler includes all TypeScript (\*.ts or \*.tsx) files in the containing directory and subdirectories except for those files or folders that are excluded.
 
 The `"files"` property cannot be used in conjunction with the `"exclude"` property. If both are specified then the `"files"` property takes precedence.
 


### PR DESCRIPTION
Trying to make it clear that this can be directories or files.

We recently implemented this in `grunt-ts`.  Even though all of the examples are with directory names, `exclude` can also accept file names and I wanted to make that clearer.