### PR TITLE
--isolatedModules fix

### DIFF
--- a/Setting-Compiler-Options-in-MSBuild-projects.md
+++ b/Setting-Compiler-Options-in-MSBuild-projects.md
@@ -26,9 +26,9 @@ Compiler options can be specified using MSBuild properties within an MSBuild pro
 `--emitBOM`                                  | TypeScriptEmitBOM                          | boolean
 `--emitDecoratorMetadata`                    | TypeScriptEmitDecoratorMetadata            | boolean
 `--experimentalDecorators`                   | TypeScriptExperimentalDecorators           | boolean
-`--inlineSourceMap`                          | TypeScriptInlineSourceMap                  |  boolean
-`--inlineSources`                            | TypeScriptInlineSources                    |  boolean
-`--locale`                                   | Automatically set to PreferredUILang value |
+`--inlineSourceMap`                          | TypeScriptInlineSourceMap                  | boolean
+`--inlineSources`                            | TypeScriptInlineSources                    | boolean
+`--locale`                                   | *automatic*                                | Automatically set to PreferredUILang value
 `--mapRoot`                                  | TypeScriptMapRoot                          | File path
 `--newLine`                                  | TypeScriptNewLine                          | `CRLF` or `LF`
 `--noEmitOnError`                            | TypeScriptNoEmitOnError                    | boolean

--- a/Setting-Compiler-Options-in-MSBuild-projects.md
+++ b/Setting-Compiler-Options-in-MSBuild-projects.md
@@ -41,7 +41,7 @@ Compiler options can be specified using MSBuild properties within an MSBuild pro
 `--preserveConstEnums`                       | TypeScriptPreserveConstEnums               | boolean
 `--removeComments`                           | TypeScriptRemoveComments                   | boolean
 `--rootDir`                                  | TypeScriptRootDir                          | File path
-`--separateCompilation`                      | TypeScriptSingleFile                       | boolean
+`--isolatedModules`                          | TypeScriptIsolatedModules                  | boolean
 `--sourceMap`                                | TypeScriptSourceMap                        | File path
 `--sourceRoot`                               | TypeScriptSourceRoot                       | File path
 `--suppressImplicitAnyIndexErrors`           | TypeScriptSuppressImplicitAnyIndexErrors   | boolean


### PR DESCRIPTION
This fixes the documentation for using --isolatedModules with Visual Studio.  Also minor formatting changes.