### PR TITLE
Make command line option descriptions more consistent

### DIFF
--- a/Compiler-Options.md
+++ b/Compiler-Options.md
@@ -21,9 +21,9 @@ Option | Shorthand | Description
 `--locale` | | The locale to use to show error messages, e.g. en-us.
 `--mapRoot` | | Specifies the location where debugger should locate map files instead of generated locations. Use this flag if the .map files will be located at run-time in a different location than than the .js files. The location specified will be embedded in the sourceMap to direct the debugger where the map files where be located.
 `--moduleResolution`<sup>[1]</sup> | | Determine how modules get resolved. Either 'node' for Node.js/io.js style resolution, or 'classic' (default).
-`--newLine` | | Specifies the end of line sequence to be used when emitting files: 'CRLF' (dos) or 'LF' (unix)."
-`--noEmit` | | Uses the specified end of line sequence when emitting files.
-`--noEmitOnError` | | Uses the specified end of line sequence when emitting files if any errors were reported.
+`--newLine` | | Use the specified end of line sequence to be used when emitting files: 'CRLF' (dos) or 'LF' (unix)."
+`--noEmit` | | Do not emit outputs.
+`--noEmitOnError` | | Do not emit outputs if any errors were reported.
 `--noEmitHelpers` | | Do not generate custom helper functions like `__extends` in compiled output.
 `--noImplicitAny` | | Raise error on expressions and declarations with an implied 'any' type.
 `--noLib` | | Do not include the default library file (lib.d.ts).

--- a/Compiler-Options.md
+++ b/Compiler-Options.md
@@ -22,8 +22,8 @@ Option | Shorthand | Description
 `--mapRoot` | | Specifies the location where debugger should locate map files instead of generated locations. Use this flag if the .map files will be located at run-time in a different location than than the .js files. The location specified will be embedded in the sourceMap to direct the debugger where the map files where be located.
 `--moduleResolution`<sup>[1]</sup> | | Determine how modules get resolved. Either 'node' for Node.js/io.js style resolution, or 'classic' (default).
 `--newLine` | | Specifies the end of line sequence to be used when emitting files: 'CRLF' (dos) or 'LF' (unix)."
-`--noEmit` | | Do not emit outputs.
-`--noEmitOnError` | | Do not emit outputs if any errors were reported.
+`--noEmit` | | Uses the specified end of line sequence when emitting files.
+`--noEmitOnError` | | Uses the specified end of line sequence when emitting files if any errors were reported.
 `--noEmitHelpers` | | Do not generate custom helper functions like `__extends` in compiled output.
 `--noImplicitAny` | | Raise error on expressions and declarations with an implied 'any' type.
 `--noLib` | | Do not include the default library file (lib.d.ts).


### PR DESCRIPTION
Fixes [#4825](https://github.com/Microsoft/TypeScript/issues/4825) (from the original [**Microsoft / TypeScript**](https://github.com/Microsoft/TypeScript) repo).