### PR TITLE
Fixed period/comma typo in Breakin-Changes.md

### DIFF
--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -430,7 +430,7 @@ class C extends CBase<string> {
 See issues [#1425](https://github.com/Microsoft/TypeScript/issues/1425) and [#920](https://github.com/Microsoft/TypeScript/issues/920) for more details.
 
 #### DOM interface changes
-TypeScript 1.5 refreshes the DOM types in lib.d.ts. This is the first major refresh since TypeScript 1.0; many IE-specific definitions have been removed in favor of the standard DOM definitions. as well as adding missing types like Web Audio and touch events.
+TypeScript 1.5 refreshes the DOM types in lib.d.ts. This is the first major refresh since TypeScript 1.0; many IE-specific definitions have been removed in favor of the standard DOM definitions, as well as adding missing types like Web Audio and touch events.
 
 **Workaround:**
 


### PR DESCRIPTION
Under 1.5 > DOM interface changes, there was a period that should have been a comma.