### PR TITLE
Typo in code description ("400ms" should be "200ms")

### DIFF
--- a/What's-new-in-TypeScript.md
+++ b/What's-new-in-TypeScript.md
@@ -582,7 +582,7 @@ Asynchronous functions are prefixed with the `async` keyword; `await` suspends t
 
 ##### Example
 
-In the following example, each input element will be printed out one at a time with a 400ms delay:
+In the following example, each input element will be printed out one at a time with a 200ms delay:
 
 ```ts
 "use strict";


### PR DESCRIPTION
The code example for await/async waits for 200ms, while the comment above it mentions 400ms.