### PR TITLE
Remove extra quote

### DIFF
--- a/What's-new-in-TypeScript.md
+++ b/What's-new-in-TypeScript.md
@@ -682,7 +682,7 @@ For example:
 ##### math-lib.d.ts
 
 ```ts
-export const isPrime(x: number): boolean;'
+export const isPrime(x: number): boolean;
 export as namespace mathLib;
 ```
 


### PR DESCRIPTION
There was a dangling quote that wasn't supposed to be there.