### PR TITLE
Removed typo 'WildChard' and changed to 'Wildcard'

### DIFF
--- a/What's-new-in-TypeScript.md
+++ b/What's-new-in-TypeScript.md
@@ -652,7 +652,7 @@ import data from "json!http://example.com/data.json";
 console.log(data, fileContent);
 ```
 
-WildChard module names can be even more useful when migrating from an un-typed code base.
+Wildcard module names can be even more useful when migrating from an un-typed code base.
 Combined with Shorthand ambient module declarations, a set of modules can be easily declared as `any`.
 
 #### Example


### PR DESCRIPTION
Simple typo in the wiki WildChard should be Wildcard