### PR TITLE
Make it clear that bind is ES5 or newer

### DIFF
--- a/'this'-in-TypeScript.md
+++ b/'this'-in-TypeScript.md
@@ -111,5 +111,5 @@ window.setTimeout(x.someMethod.bind(x), 100);
  * Good/bad: Opposite memory/performance trade-off compared to using instance functions
  * Good: No extra work if the function has parameters
  * Bad: In TypeScript, this currently has no type safety
- * Bad: Only available in ECMAScript 5, if that matters
+ * Bad: Only available in [ECMAScript 5](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) or newer
  * Bad: You have to type the instance name twice


### PR DESCRIPTION
Previously this sounded as if it was ES5 only and not ES6.

I also added a link to the MDN for `Function.prototype.bind()`.