### PR TITLE
Remove link to old vim plugin

### DIFF
--- a/TypeScript-Editor-Support.md
+++ b/TypeScript-Editor-Support.md
@@ -56,10 +56,7 @@ The [TypeScript Plugin for Sublime](https://github.com/Microsoft/TypeScript-Subl
 
 ### Language Service Tools
 
-There are two main TypeScript plugins:
-
 * [Quramy/tsuquyomi](https://github.com/Quramy/tsuquyomi)
-* [clausreinke/typescript-tools.vim](https://github.com/clausreinke/typescript-tools.vim)
 
 If you would like to have as-you-type completion, you can install [YouCompleteMe](https://github.com/Valloric/YouCompleteMe) and add the following code into your `.vimrc` to specify what token will trigger the completion. YouCompleteMe will call into its respective TypeScript Plugin for semantic queries.
 


### PR DESCRIPTION
typescript-tools.vim hasn't been updated into a couple of years.
Tsuquyomi is still active.

@DanielRosenwasser are you ok with this change? 

In addition, maybe on typescriptlang we should just have the Vim icon link to tsuquyomi because its README lists all the plugins you might want to install &mdash; better than our 1 paragraph.