### PR TITLE
Document how to define a constructor parameter

### DIFF
--- a/JSDoc-support-in-JavaScript.md
+++ b/JSDoc-support-in-JavaScript.md
@@ -135,6 +135,14 @@ let myArrow = x => x * x;
 var sfc = (test) => <div>{test.a.charAt(0)}</div>;
 
 
+/**
+ * A parameter can be a class constructor.
+ *
+ * @param {{new(...args: any[]): Object}} C - The class to register
+ */
+function registerClass(C) {}
+
+
 
 // === Below forms are not supported ===
 

--- a/JSDoc-support-in-JavaScript.md
+++ b/JSDoc-support-in-JavaScript.md
@@ -138,7 +138,7 @@ var sfc = (test) => <div>{test.a.charAt(0)}</div>;
 /**
  * A parameter can be a class constructor.
  *
- * @param {{new(...args: any[]): Object}} C - The class to register
+ * @param {{new(...args: any[]): object}} C - The class to register
  */
 function registerClass(C) {}
 


### PR DESCRIPTION
It took a while to figure out the syntax for defining a constructor parameter (or return type) in jsDoc notation, so I thought it was worth adding that to the docs.