### PR TITLE
Fix formatting in disclaimer

### DIFF
--- a/Using-the-Compiler-API.md
+++ b/Using-the-Compiler-API.md
@@ -1,4 +1,4 @@
-> ##*Disclaimer*
+> ## *Disclaimer*
 Keep in mind that this is not yet a stable API - we’re releasing this as version 0.5, and things will be changing over time. As a first iteration, there will be a few rough edges. We encourage any and all feedback from the community to improve the API. To allow users to transition between future releases, we will be documenting any [[API Breaking Changes]] per new release.
 
 ## Getting set up


### PR DESCRIPTION
Without the space between `#` and `*`, this just looks like

 > ##*Disclaimer*