### PR TITLE
JSDoc: add documentation for class @property declarations

### DIFF
--- a/JSDoc-support-in-JavaScript.md
+++ b/JSDoc-support-in-JavaScript.md
@@ -210,15 +210,14 @@ function fn10(/** string */ p1){}
  * @property {string[]} keys
  */
 class Foo {
-	/**
-	 * @param {string} [name = 'Foo']
-	 * @param {string[]} keys
-	 */
+    /**
+     * @param {string} [name = 'Foo']
+     * @param {string[]} keys
+     */
 	constructor(name = 'Foo', keys) {
-		this.name = name;
-		/** @type {string[]} keys */
-		this.keys = keys;
-	}
+        this.name = name;
+        /** @type {string[]} keys */
+        this.keys = keys;
+    }
 }
-
 ```

--- a/JSDoc-support-in-JavaScript.md
+++ b/JSDoc-support-in-JavaScript.md
@@ -214,7 +214,7 @@ class Foo {
      * @param {string} [name = 'Foo']
      * @param {string[]} keys
      */
-	constructor(name = 'Foo', keys) {
+        constructor(name = 'Foo', keys) {
         this.name = name;
         /** @type {string[]} keys */
         this.keys = keys;

--- a/JSDoc-support-in-JavaScript.md
+++ b/JSDoc-support-in-JavaScript.md
@@ -203,4 +203,22 @@ function fn9(p1){}
 // Inline JsDoc comments (treated as 'any')
 function fn10(/** string */ p1){}
 
+// Class property declarations. Array properties will still need a @type
+// declaration within the constructor.
+/**
+ * @property {string} name
+ * @property {string[]} keys
+ */
+class Foo {
+	/**
+	 * @param {string} [name = 'Foo']
+	 * @param {string[]} keys
+	 */
+	constructor(name = 'Foo', keys) {
+		this.name = name;
+		/** @type {string[]} keys */
+		this.keys = keys;
+	}
+}
+
 ```


### PR DESCRIPTION
I noticed `@property` declarations appear to be supported, but are not
documented in the wiki.