### PR TITLE
Document TypeScript 2.5 checkJs cast syntax

### DIFF
--- a/Type-Checking-JavaScript-Files.md
+++ b/Type-Checking-JavaScript-Files.md
@@ -20,6 +20,12 @@ x = 0;      // OK
 x = false;  // Error: boolean is not assignable to number
 ```
 
+Types can be cast:
+
+```js
+var x = /** @type {SomeType} */ (AnyParenthesizedExpression);
+```
+
 You can find the full list of supported JSDoc patterns in the [JSDoc support in JavaScript documentation](https://github.com/Microsoft/TypeScript/wiki/JSDoc-support-in-JavaScript).
 
 ## Property declaration inferred from assignments in class bodies


### PR DESCRIPTION
TypeScript 2.5 introduced a new JSDoc-based cast syntax that looks like this:

```js
var x = /** @type {SomeType} */ (AnyParenthesizedExpression);
```

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-5.html#type-assertioncast-syntax-in-checkjsts-check-mode

It was documented in the announcement, but not anywhere else. This adds it to the "Type Checking JavaScript Files" page, which is probably the best place for it to go.