### PR TITLE
Remove incorrect statement about shared private members

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1099,43 +1099,6 @@ The easiest fix is to use the `typeof` type operator.
 
 ## Things That Don't Work
 
-### You should emit classes like this so they have real private members
-
-> If I write code like this:
-> ```ts
-> class Foo {
->     private x = 0;
->     increment(): number {
->         this.x++;
->         return x;
->     }
-> }
-> ```
-> You should emit code like this so that 'x' is truly private:
-> ```js
-> var Foo = (function () {
->     var x = 0;
-> 
->     function Foo() {
->     }
->     Foo.prototype.increment = function () {
->         x++;
->         return x;
->     };
->     return Foo;
-> })();
-> ```
-
-This code doesn't work.
-It creates a *single* private field that all classes share:
-```js
-var a = new Foo();
-a.increment(); // Prints 1
-a.increment(); // Prints 2
-var b = new Foo(); // Should not affect a
-a.increment(); // Prints 1
-```
-
 ### You should emit classes like this so they don't lose `this` in callbacks
 > If I write code like this:
 > ```ts


### PR DESCRIPTION
The FAQ section ["Things That Don't Work", subsection "You should emit classes like this so they have real private members"](https://github.com/Microsoft/TypeScript/wiki/FAQ#you-should-emit-classes-like-this-so-they-have-real-private-members) incorrectly states that declaring a private property would make "a single private field that all classes share". 

It provides an example:

```
class Foo {
    private x = 0;
    increment(): number {
        this.x++;
        return x;
    }
}
```

And then:

```
var a = new Foo();
a.increment(); // Prints 1
a.increment(); // Prints 2
var b = new Foo(); // Should not affect a
a.increment(); // Prints 1
```

In fact, the code does not print `1`, but correctly prints `3` instead. This can be tested on [TypeScript Playground](https://www.typescriptlang.org/play/#src=class%20Foo%20%7B%0D%0A%20%20%20%20private%20x%20%3D%200%3B%0D%0A%20%20%20%20increment()%3A%20number%20%7B%0D%0A%20%20%20%20%20%20%20%20this.x%2B%2B%3B%0D%0A%20%20%20%20%20%20%20%20return%20this.x%3B%0D%0A%20%20%20%20%7D%0D%0A%7D%0D%0A%0D%0Avar%20a%20%3D%20new%20Foo()%3B%0D%0Aa.increment()%3B%20%2F%2F%20Prints%201%0D%0Aconsole.log(a.increment())%3B%20%2F%2F%20Prints%202%0D%0A%0D%0Avar%20b%20%3D%20new%20Foo()%3B%20%2F%2F%20Should%20not%20affect%20a%0D%0A%0D%0A%2F%2F%20Prints%203%2C%20not%201%20as%20stated%20in%20the%20docs%0D%0Aconsole.log(a.increment())%3B%20%0D%0A).

This pull request removes the incorrect statement.