### PR TITLE
Correct signature of isReallyInstanceOf

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -969,7 +969,7 @@ function create<T>(ctor: { new(): T }) {
 }
 var c = create(MyClass); // c: MyClass
 
-function isReallyInstanceOf<T>(ctor: { new(...args: any) => T }, obj: T) {
+function isReallyInstanceOf<T>(ctor: { new(...args: any[]): T }, obj: T) {
   return obj instanceof ctor;
 }
 ```


### PR DESCRIPTION
I pasted the isReallyInstanceOf<T> function into my editor and TypeScript (version 2.6.1) immediately caught two errors in the function signature:

> A rest parameter must be of an array type.

`{ ctor: { new(...args: any) => T }` -> `{ ctor: { new(...args: any[]) => T }`

> ':' expected.

`{ ctor: { new(...args: any[]) => T }` -> `{ ctor: { new(...args: any[]): T }`