### PR TITLE
Change node --debug to node --inspect

### DIFF
--- a/Debugging-Language-Service-in-VS-Code.md
+++ b/Debugging-Language-Service-in-VS-Code.md
@@ -58,7 +58,7 @@ From here, there are different steps for debugging the client- and server-side, 
        "sourceMaps": true,
        "outFiles": ["/path/to/repo/TypeScript/built/local"],
        "runtimeArgs": [
-           "--debug=5859"
+           "--inspect=5859"
        ]
    }
    ```


### PR DESCRIPTION
This commit fixes the following deprecation:
DeprecationWarning: `node --debug` and `node --debug-brk` are invalid. Please use `node --inspect` or `node --inspect-brk` instead.