### PR TITLE
Add nvim-typescript as an option for Vim 8

### DIFF
--- a/TypeScript-Editor-Support.md
+++ b/TypeScript-Editor-Support.md
@@ -78,7 +78,7 @@ let g:ycm_semantic_triggers['typescript'] = ['.']
 
 * [mhartington/nvim-typescript](https://github.com/mhartington/nvim-typescript)
 
-As-you-type deoplete asynchronous completion framework for Vim8. Needs [Shougo/deoplete.nvim] https://github.com/Shougo/deoplete.nvim in order to work.
+As-you-type deoplete asynchronous completion framework for Vim 8. Needs [Shougo/deoplete.nvim](https://github.com/Shougo/deoplete.nvim) in order to work.
 
 # Visual Studio 2013/2015
 

--- a/TypeScript-Editor-Support.md
+++ b/TypeScript-Editor-Support.md
@@ -76,6 +76,9 @@ endif
 let g:ycm_semantic_triggers['typescript'] = ['.']
 ```
 
+* [mhartington/nvim-typescript](https://github.com/mhartington/nvim-typescript)
+As-you-type deoplete asynchronous completion framework for Vim8. Needs [Shougo/deoplete.nvim] https://github.com/Shougo/deoplete.nvim in order to work.
+
 # Visual Studio 2013/2015
 
 [Visual Studio](https://www.visualstudio.com/) comes with TypeScript when installing Microsoft Web Tools.

--- a/TypeScript-Editor-Support.md
+++ b/TypeScript-Editor-Support.md
@@ -77,6 +77,7 @@ let g:ycm_semantic_triggers['typescript'] = ['.']
 ```
 
 * [mhartington/nvim-typescript](https://github.com/mhartington/nvim-typescript)
+
 As-you-type deoplete asynchronous completion framework for Vim8. Needs [Shougo/deoplete.nvim] https://github.com/Shougo/deoplete.nvim in order to work.
 
 # Visual Studio 2013/2015


### PR DESCRIPTION
Although nvim-typescript is mainly focused for nvim usage it can be also used for Vim 8 according to its [requierements](https://github.com/Shougo/deoplete.nvim#requirements)