### PR TITLE
Use prettier for code examples that have a too long width

### DIFF
--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -6,7 +6,7 @@ These changes list where implementation differs between versions as the spec and
 
 ## `keyof` now includes `string`, `number` and `symbol` keys
 
-TypeScript 2.9 generalizes index types to include `number` and `symbol` named properties. Previously, the `keyof` operator and mapped types only supported `string` named properties. 
+TypeScript 2.9 generalizes index types to include `number` and `symbol` named properties. Previously, the `keyof` operator and mapped types only supported `string` named properties.
 
 ```ts
 function useKey<T, K extends keyof T>(o: T, k: K) {
@@ -19,7 +19,7 @@ function useKey<T, K extends keyof T>(o: T, k: K) {
 
   ```ts
   function useKey<T, K extends Extract<keyof T, string>>(o: T, k: K) {
-    var name: string = k;  // OK 
+    var name: string = k;  // OK
   }
   ```
 
@@ -27,7 +27,7 @@ function useKey<T, K extends keyof T>(o: T, k: K) {
 
   ```ts
   function useKey<T, K extends keyof T>(o: T, k: K) {
-    var name: string | number | symbol = k; 
+    var name: string | number | symbol = k;
   }
   ```
 
@@ -183,11 +183,11 @@ else {
 Previously classes that were structurally equivalent were reduced to their best common type in a conditional or `||` operator. Now these classes are maintained in a union type to allow for more accurate checking for `instanceof` operators.
 
 ```ts
-class Animal { 
+class Animal {
 
 }
 
-class Dog { 
+class Dog {
     park() { }
 }
 
@@ -236,7 +236,7 @@ Now when the `--noUnusedLocals` and `--noUnusedParameters` [compiler options](ht
 Also recursive functions that are only called within their own bodies are considered unused.
 
 ```ts
-function f() { 
+function f() {
     f(); // Error: 'f' is declared but its value is never read
 }
 ```
@@ -365,11 +365,13 @@ that takes a callback, which takes a nested callback. The nested
 callback is now checked co-variantly.
 
 ```ts
-declare function f(callback: (nested: (error: number, result: any) => void, index: number) => void): void;
+declare function f(
+  callback: (nested: (error: number, result: any) => void, index: number) => void
+): void;
 
 f((nested: (error: number) => void) => { log(error) });
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  '(error: number) => void' is not assignable to (error: number, result: any) => void'
+'(error: number) => void' is not assignable to (error: number, result: any) => void'
 ```
 
 The fix is easy in this case. Just add the missing parameter to the
@@ -637,10 +639,10 @@ let y = (void a, 1); // no warning for `a`
 
 ## Changes to DOM API's in the standard library
 
-* **Node.firstChild**, **Node.lastChild**, **Node.nextSibling**, **Node.previousSibling**, **Node.parentElement** and **Node.parentNode** are now `Node | null` instead of `Node`. 
- 
- See [#11113](https://github.com/Microsoft/TypeScript/issues/11113) for more details. 
- 
+* **Node.firstChild**, **Node.lastChild**, **Node.nextSibling**, **Node.previousSibling**, **Node.parentElement** and **Node.parentNode** are now `Node | null` instead of `Node`.
+
+ See [#11113](https://github.com/Microsoft/TypeScript/issues/11113) for more details.
+
  Recommendation is to explicitly check for `null` or use the `!` assertion operator (e.g. `node.lastChild!`).
 
 # TypeScript 2.0

--- a/FAQ.md
+++ b/FAQ.md
@@ -229,11 +229,11 @@ so we have to take a correctness trade-off for the specific case of function arg
 > function handler(arg: string) {
 >     // ....
 > }
-> 
+>
 > function doSomething(callback: (arg1: string, arg2: number) => void) {
 >     callback('hello', 42);
 > }
-> 
+>
 > // Expected error because 'doSomething' wants a callback of
 > // 2 parameters, but 'handler' only accepts 1
 > doSomething(handler);
@@ -293,12 +293,13 @@ which would be "fixed", but *not made any more correct*, by adding a parameter:
 > function doSomething(): number {
 >     return 42;
 > }
-> 
+>
 > function callMeMaybe(callback: () => void) {
 >     callback();
 > }
-> 
-> // Expected an error because 'doSomething' returns number, but 'callMeMaybe' expects void-returning function
+>
+> // Expected an error because 'doSomething' returns number, but 'callMeMaybe'
+> // expects void-returning function
 > callMeMaybe(doSomething);
 > ```
 
@@ -426,7 +427,7 @@ See also [#202](https://github.com/Microsoft/TypeScript/issues/202) for a sugges
 > interface SomeOtherInterface {
 >   questions: string[];
 > }
-> 
+>
 > function f(x: SomeInterface|SomeOtherInterface) {
 >   // Can't use instanceof on interface, help?
 >   if (x instanceof SomeInterface) {
@@ -502,16 +503,16 @@ To avoid this problem, turn on the `noImplicitAny` flag, which will issue a warn
 > interface StringMap {
 >   [key: string]: string;
 > }
-> 
+>
 > function a(): StringMap {
 >   return { a: "1" }; // OK
 > }
-> 
+>
 > function b(): StringMap {
 >   var result: StringMap = { a: "1" };
 >   return result; // OK
 > }
-> 
+>
 > function c(): StringMap {
 >   var result = { a: "1" };
 >   return result; // Error - result lacks index signature, why?
@@ -607,15 +608,15 @@ function createLog(source:string, message?:string): number {
 }
 ```
 
-The rationale here is that since JavaScript does not have function overloading, you will be doing parameter checking in your function, and this your function implementation might be more permissive that what you would want your users to call you through. 
+The rationale here is that since JavaScript does not have function overloading, you will be doing parameter checking in your function, and this your function implementation might be more permissive that what you would want your users to call you through.
 
 For instance you can require your users to call you using matching pairs of arguments, and implement this correctly without having to allow mixed argument types:
 
 ```ts
 function compare(a: string, b: string): void;
 function compare(a: number, b: number): void;
-function compare(a: string|number, b: string|number): void { // Just an implementation and not visible to callers
-
+function compare(a: string|number, b: string|number): void {
+  // Just an implementation and not visible to callers
 }
 
 compare(1,2) // OK
@@ -672,7 +673,7 @@ function f({x = 0}) {
 > I wrote some code like this and expected an error:
 > ```ts
 > class Empty { /* empty */ }
-> 
+>
 > var e2: Empty = window;
 > ```
 
@@ -724,10 +725,10 @@ When a member is private or protected, it must *originate in the same declaratio
 >     this.someMethod(); // Throws error "this.method is not a function"
 >   }
 >   someMethod() {
->     
->   } 
+>
+>   }
 > }
-> 
+>
 > let obj = new MyClass();
 > window.setTimeout(obj.someCallback, 10);
 > ```
@@ -801,13 +802,13 @@ See http://stackoverflow.com/a/14348084/1704166
 ### What does it mean for an interface to extend a class?
 
 > What does this code mean?
-> 
+>
 > ```ts
 > class Foo {
 >   /* ... */
 > }
 > interface Bar extends Foo {
->   
+>
 > }
 > ```
 
@@ -821,7 +822,7 @@ In general, this pattern is best avoided, especially if `Foo` has private member
 > ```ts
 > /** file1.ts **/
 > class Alpha { /* ... */ }
-> 
+>
 > /** file2.ts **/
 > class Bravo extends Alpha { /* ... */ }
 > ```
@@ -838,7 +839,7 @@ Add a script tag for the base class's output *before* the script tag for the der
 > ```ts
 > /** file1.ts **/
 > class Alpha { /* ... */ }
-> 
+>
 > /** file2.ts **/
 > class Bravo extends Alpha { /* ... */ }
 > ```
@@ -956,7 +957,7 @@ The type will have unexpected compatibility (as shown here) and will also fail t
 >   // TODO: Implement
 >   return undefined;
 > }
-> 
+>
 > var x: MyNamed<string>;
 > var y = findByName(x); // expected y: string, got y: {}
 > ```
@@ -998,7 +999,7 @@ See the previous question for more reasons why this is bad.
 >   let y = new xType();
 >   // Same here?
 >   if(someVar instanceof typeof T) {
-> 
+>
 >   }
 >   // How do I instantiate?
 >   let z = new T();
@@ -1025,18 +1026,18 @@ function isReallyInstanceOf<T>(ctor: { new(...args: any[]): T }, obj: T) {
 ## Modules
 
 ### Why are imports being elided in my emit?
- 
+
 > I wrote some code like this
 > ```ts
 > import someModule = require('./myMod');
-> 
+>
 > let x: someModule.SomeType = /* something */;
 > ```
-> 
+>
 > and the emit looked like this:
 > ```js
 > // Expected to see "var someModule = require('./myMod');" here!
-> 
+>
 > var x = /* something */;
 > ```
 
@@ -1122,7 +1123,7 @@ TODO: Answer
 > class Display extends React.Component<any, any> {
 >     render() { ... }
 > }
-> 
+>
 > let SomeThing: Display = /* ... */;
 > // Error here, isn't this OK?
 > let jsx = <SomeThing />;
@@ -1162,7 +1163,7 @@ The easiest fix is to use the `typeof` type operator.
 > ```js
 > var Foo = (function () {
 >     var x = 0;
-> 
+>
 >     function Foo() {
 >     }
 >     Foo.prototype.increment = function () {
@@ -1196,7 +1197,7 @@ a.increment(); // Prints 1
 > var MyClass = (function () {
 >     function MyClass() {
 > 		this.method = function() {
-> 			
+>
 > 		}
 >     }
 >     return MyClass;
@@ -1253,7 +1254,7 @@ TODO: Port content from [#1617](https://github.com/Microsoft/TypeScript/issues/1
 ## External Tools
 
 ### How do I write unit tests with TypeScript?
-TODO: Answer
+* [Typescript Deep Dive](https://basarat.gitbooks.io/typescript/docs/testing/jest.html)
 
 
 -------------------------------------------------------------------------------------
@@ -1270,9 +1271,9 @@ TODO: Answer
 > }
 > doSomething();
 > ```
-> 
+>
 > I compiled it with `tsc --module commonjs myApp.ts --out app.js` and ran `node app.js` and got the expected output.
-> 
+>
 > Then I added an `import` to it:
 > ```ts
 > import fs = require('fs');
@@ -1281,7 +1282,7 @@ TODO: Answer
 > }
 > doSomething();
 > ```
-> 
+>
 > Or added an `export` to it:
 > ```ts
 > export function doSomething() {
@@ -1289,12 +1290,12 @@ TODO: Answer
 > }
 > doSomething();
 > ```
-> 
+>
 > And now nothing happens when I run `app.js`!
 
 Modules -- those files containing top-level `export` or `import` statements -- are always compiled 1:1 with their corresponding js files.
 The `--out` option only controls where *script* (non-module) code is emitted.
-In this case, you should be running `node myApp.js`, because the *module* `myApp.ts` is always emitted to the file `myApp.js`.  
+In this case, you should be running `node myApp.js`, because the *module* `myApp.ts` is always emitted to the file `myApp.js`.
 
 This behavior has been fixed as of TypeScript 1.8; combining `--out` and `--module` is now an error for CommonJS module output.
 
@@ -1355,7 +1356,7 @@ To ensure the output does not change with adding new files specify `--rootDir` o
 
 ### Why is a file in the `exclude` list still picked up by the compiler?
 
-`tsconfig.json` turns a folder into a “project”. Without specifying any `“exclude”` or `“files”` entries, all files in the folder containing the `tsconfig.json` and all its sub-directories are included in your compilation. 
+`tsconfig.json` turns a folder into a “project”. Without specifying any `“exclude”` or `“files”` entries, all files in the folder containing the `tsconfig.json` and all its sub-directories are included in your compilation.
 
 If you want to exclude some of the files use `“exclude”`, if you would rather specify all the files instead of letting the compiler look them up, use `“files”`.
 
@@ -1375,7 +1376,7 @@ For a TypeScript file, the TypeScript compiler by default emits the generated Ja
 Because the TypeScript files and emitted JavaScript files always have different file extensions, it is safe to do so.
 However, if you have set the `allowJs` compiler option to `true` and didn't set any emit output options (`outFile` and `outDir`), the compiler will try to emit JavaScript source files by the same rule, which will result in the emitted JavaScript file having the same file name with the source file. To avoid accidently overwriting your source file, the  compiler will issue this warning and skip writing the output files.
 
-There are multiple ways to solve this issue, though all of them involve configuring compiler options, therefore it is recommended that you have a `tsconfig.json` file in the project root to enable this. 
+There are multiple ways to solve this issue, though all of them involve configuring compiler options, therefore it is recommended that you have a `tsconfig.json` file in the project root to enable this.
 If you don't want JavaScript files included in your project at all, simply set the `allowJs` option to `false`;
 If you do want to include and compile these JavaScript files, set the `outDir` option or `outFile` option to direct the emitted files elsewhere, so they won't conflict with your source files;
 If you just want to include the JavaScript files for editing and don't need to compile, set the `noEmit` compiler option to `true` to skip the emitting check.

--- a/What's-new-in-TypeScript.md
+++ b/What's-new-in-TypeScript.md
@@ -88,8 +88,8 @@ const symbolToNumberMap = {
     [sym3]: 3
 };
 
-type KE = keyof typeof enumToStringMap;     // Enum (i.e. Enum.A | Enum.B | Enum.C)
-type KS = keyof typeof symbolToNumberMap;   // typeof sym1 | typeof sym2 | typeof sym3
+type KE = keyof typeof enumToStringMap;   // Enum (i.e. Enum.A | Enum.B | Enum.C)
+type KS = keyof typeof symbolToNumberMap; // typeof sym1 | typeof sym2 | typeof sym3
 
 function getValue<T, K extends keyof T>(obj: T, key: K): T[K] {
     return obj[key];
@@ -688,7 +688,7 @@ C.prototype.q = function(r) {
 
 ### Nested and merged declarations
 
-Nesting works to any level now, and merges correctly across files. Previously neither was the case. 
+Nesting works to any level now, and merges correctly across files. Previously neither was the case.
 
 ```js
 var app = window.app || {};
@@ -824,7 +824,7 @@ class C {
     bar = "hello";
     baz: boolean;
 //  ~~~
-//  Error! Property 'baz' has no initializer and is not definitely assigned in the 
+//  Error! Property 'baz' has no initializer and is not definitely assigned in the
 //         constructor.
 
     constructor() {
@@ -938,10 +938,10 @@ interface MinimumNumStrTuple extends Array<number | string> {
 
 Note that this does not imply tuples represent immutable arrays, but it is an implied convention.
 
-## Improved type inference for object literals 
+## Improved type inference for object literals
 
 TypeScript 2.7 improves type inference for multiple object literals occurring in the same context.
-When multiple object literal types contribute to a union type, we now *normalize* the object literal types such that all properties are present in each constituent of the union type. 
+When multiple object literal types contribute to a union type, we now *normalize* the object literal types such that all properties are present in each constituent of the union type.
 
 Consider:
 
@@ -950,7 +950,7 @@ const obj = test ? { text: "hello" } : {};  // { text: string } | { text?: undef
 const s = obj.text;  // string | undefined
 ```
 
-Previously type `{}` was inferred for `obj` and the second line subsequently caused an error because `obj` would appear to have no properties. 
+Previously type `{}` was inferred for `obj` and the second line subsequently caused an error because `obj` would appear to have no properties.
 That obviously wasn't ideal.
 
 #### Example
@@ -984,9 +984,9 @@ TypeScript 2.7 improves the handling of structurally identical classes in union 
 * Union type subtype reduction only removes a class type if it is a subclass of *and* derives from another class type in the union.
 * Type checking of the `instanceof` operator is now based on whether the type of the left operand *derives from* the type indicated by the right operand (as opposed to a structural subtype check).
 
-This means that union types and `instanceof` properly distinguish between structurally identical classes. 
+This means that union types and `instanceof` properly distinguish between structurally identical classes.
 
-#### Example: 
+#### Example:
 
 ```ts
 class A {}
@@ -1042,7 +1042,7 @@ The change brings the generated output from TypeScript closer to that generated 
 
 Previously CommonJS/AMD/UMD modules were treated in the same way as ES6 modules, resulting in a couple of problems. Namely:
 
-* TypeScript treats a namespace import (i.e. `import * as foo from "foo"`) for a CommonJS/AMD/UMD module as equivalent to `const foo = require("foo")`. 
+* TypeScript treats a namespace import (i.e. `import * as foo from "foo"`) for a CommonJS/AMD/UMD module as equivalent to `const foo = require("foo")`.
 Things are simple here, but they don't work out if the primary object being imported is a primitive or a class or a function.
 ECMAScript spec stipulates that a namespace record is a plain object, and that a namespace import (`foo` in the example above) is not callable, though allowed by TypeScript
 
@@ -1053,7 +1053,7 @@ Under the new `--esModuleInterop` these two issues should be addressed:
 * A namespace import (i.e. `import * as foo from "foo"`) is now correctly flagged as uncallabale. Calling it will result in an error.
 * Default imports to CommonJS/AMD/UMD are now allowed (e.g. `import fs from "fs"`), and should work as expected.
 
-> Note: The new behavior is added under a flag to avoid unwarranted breaks to existing code bases. We highly recommend applying it both to new and existing projects. 
+> Note: The new behavior is added under a flag to avoid unwarranted breaks to existing code bases. We highly recommend applying it both to new and existing projects.
 > For existing projects, namespace imports (`import * as express from "express"; express();`) will need to be converted to default imports (`import express from "express"; express();`).
 
 #### Example
@@ -1087,7 +1087,7 @@ var bar_1 = __importDefault(require("bar"));
 
 ## Numeric separators
 
-TypeScript 2.7 brings support for [ES Numeric Separators](https://github.com/tc39/proposal-numeric-separator). 
+TypeScript 2.7 brings support for [ES Numeric Separators](https://github.com/tc39/proposal-numeric-separator).
 Numeric literals can now be separated into segments using `_`.
 
 ##### Example
@@ -1101,12 +1101,12 @@ const word = 0b1100_0011_1101_0001;
 
 ## Cleaner output in `--watch` mode
 
-TypeScript's `--watch` mode now clears the screen after a re-compilation is requested. 
+TypeScript's `--watch` mode now clears the screen after a re-compilation is requested.
 
 ## Prettier `--pretty` output
 
 TypeScript's `--pretty` flag can make error messages easier to read and manage.
-`--pretty` now uses colors for file names, diagnostic codes, and line numbers. 
+`--pretty` now uses colors for file names, diagnostic codes, and line numbers.
 File names and positions are now also formatted to allow navigation in common terminals (e.g. Visual Studio Code terminal).
 
 
@@ -1161,8 +1161,8 @@ By the way, note that whereas some languages (e.g. C# and Scala) require varianc
 
 #### Note:
 
-Under `--strictFunctionTypes` the first assignment is still permitted if `compare` was declared as a method. 
-Effectively, `T` is bivariant in `Comparer<T>` because it is used only in method parameter positions. 
+Under `--strictFunctionTypes` the first assignment is still permitted if `compare` was declared as a method.
+Effectively, `T` is bivariant in `Comparer<T>` because it is used only in method parameter positions.
 
 ```ts
 interface Comparer<T> {
@@ -1197,7 +1197,7 @@ This contrasts with inferences from covariant positions, where we infer the *bes
 ## Support for JSX Fragment Syntax
 
 TypeScript 2.6.2 adds support for the new `<>...</>` syntax for fragments in JSX.
-It is frequently desirable to return multiple children from a component. 
+It is frequently desirable to return multiple children from a component.
 However, this is invalid, so the usual approach has been to wrap the text in an extra element, such as a `<div>` or `<span>` as shown below.
 
 ```tsx
@@ -1345,12 +1345,12 @@ wn' 'es2016.array.include' 'es2017.object' 'es2017.sharedmemory' 'es2017.string'
  --noImplicitReturns                        関数の一部のコード パスが値を返さない場合にエラーを報告します。
  --noFallthroughCasesInSwitch               switch ステートメントに case のフォールスルーがある場合にエラーを報告します。
  --types                                    コンパイルに含む型宣言ファイル。
- @<ファイル>  
+ @<ファイル>
 ```
 
 ## Suppress errors in .ts files using '// @ts-ignore' comments
 
-TypeScript 2.6 support suppressing errors in .js files using `// @ts-ignore` comments placed above the offending lines. 
+TypeScript 2.6 support suppressing errors in .js files using `// @ts-ignore` comments placed above the offending lines.
 
 #### Example
 
@@ -1366,7 +1366,7 @@ It is recommended practice to have the remainder of the comment following `@ts-i
 
 Please note that this comment only suppresses the error reporting, and we recommend you use this comments _very sparingly_.
 
-## Faster `tsc --watch` 
+## Faster `tsc --watch`
 
 TypeScript 2.6 brings a faster `--watch` implementation.
 The new version optimizes code generation and checking for code bases using ES modules.
@@ -1403,7 +1403,7 @@ Also functions that are only called within their own bodies are considered unuse
 #### Example
 
 ```ts
-function f() { 
+function f() {
     f(); // Error: 'f' is declared but its value is never read
 }
 ```

--- a/Writing-a-Language-Service-Plugin.md
+++ b/Writing-a-Language-Service-Plugin.md
@@ -31,9 +31,9 @@ Here's the minimal code that handles this injected `ts` value:
 ```ts
 import * as ts_module from "typescript/lib/tsserverlibrary";
 
-function init(modules: {typescript: typeof ts_module}) {
-    const ts = modules.typescript;
-    /* More to come here */
+function init(modules: { typescript: typeof ts_module }) {
+  const ts = modules.typescript;
+  /* More to come here */
 }
 
 export = init;
@@ -45,20 +45,22 @@ TypeScript Language Service Plugins use the [Decorator Pattern](https://en.wikip
 
 Let's fill in some more code to properly set up a decorator:
 ```ts
-function init(modules: {typescript: typeof ts_module}) {
-    const ts = modules.typescript;
+function init(modules: { typescript: typeof ts_module }) {
+  const ts = modules.typescript;
 
-    function create(info: ts.server.PluginCreateInfo) {
-        // Set up decorator
-        const proxy: ts.LanguageService = Object.create(null);        
-        for (let k of Object.keys(info.languageService) as Array<keyof ts.LanguageService>) {
-            const x = info.languageService[k];
-            proxy[k] = (...args: Array<{}>) => x.apply(info.languageService, args);
-        }
-        return proxy;
+  function create(info: ts.server.PluginCreateInfo) {
+    // Set up decorator
+    const proxy: ts.LanguageService = Object.create(null);
+    for (let k of Object.keys(info.languageService) as Array<
+      keyof ts.LanguageService
+    >) {
+      const x = info.languageService[k];
+      proxy[k] = (...args: Array<{}>) => x.apply(info.languageService, args);
     }
+    return proxy;
+  }
 
-    return { create };
+  return { create };
 }
 ```
 
@@ -88,9 +90,9 @@ We'll change the `getCompletionsAtPosition` function to remove certain entries n
 ```ts
 // Remove specified entries from completion list
 proxy.getCompletionsAtPosition = (fileName, position) => {
-    const prior = info.languageService.getCompletionsAtPosition(fileName, position);
-    prior.entries = prior.entries.filter(e => e.name !== 'caller');
-    return prior;
+  const prior = info.languageService.getCompletionsAtPosition(fileName, position);
+  prior.entries = prior.entries.filter(e => e.name !== "caller");
+  return prior;
 };
 ```
 
@@ -101,18 +103,22 @@ Users can customize your plugin behavior by providing additional data in their `
 Let's allow the user to customize the list of names to remove from the completion list:
 ```ts
 function create(info: ts.server.PluginCreateInfo) {
-    // Get a list of things to remove from the completion list from the config object.
-    // If nothing was specified, we'll just remove 'caller'
-    const whatToRemove: string[] = info.config.remove || ['caller'];
+  // Get a list of things to remove from the completion list from the config object.
+  // If nothing was specified, we'll just remove 'caller'
+  const whatToRemove: string[] = info.config.remove || ["caller"];
 
-    // ... (set up decorator here) ...
+  // ... (set up decorator here) ...
 
-    // Remove specified entries from completion list
-    proxy.getCompletionsAtPosition = (fileName, position) => {
-        const prior = info.languageService.getCompletionsAtPosition(fileName, position);
-        prior.entries = prior.entries.filter(e => whatToRemove.indexOf(e.name) < 0);
-        return prior;
-    };
+  // Remove specified entries from completion list
+  proxy.getCompletionsAtPosition = (fileName, position) => {
+    const prior = info.languageService.getCompletionsAtPosition(
+      fileName,
+      position
+    );
+    prior.entries = prior.entries.filter(e => whatToRemove.indexOf(e.name) < 0);
+    return prior;
+  };
+}
 ```
 
 The new `tsconfig.json` file might look like this:
@@ -145,7 +151,10 @@ Ensure that the containing directory (`C:\SomeFolder` in this example) exists an
 You can write to this log by calling into the TypeScript project's logging service:
 ```ts
 function create(info: ts.server.PluginCreateInfo) {
-    info.project.projectService.logger.info("I'm getting set up now! Check the log for this message.");
+  info.project.projectService.logger.info(
+    "I'm getting set up now! Check the log for this message."
+  );
+}
 ```
 
 ## Putting it all together
@@ -153,42 +162,52 @@ function create(info: ts.server.PluginCreateInfo) {
 ```ts
 import * as ts_module from "../node_modules/typescript/lib/tsserverlibrary";
 
-function init(modules: {typescript: typeof ts_module}) {
-    const ts = modules.typescript;
+function init(modules: { typescript: typeof ts_module }) {
+  const ts = modules.typescript;
 
-    function create(info: ts.server.PluginCreateInfo) {
-        // Get a list of things to remove from the completion list from the config object.
-        // If nothing was specified, we'll just remove 'caller'
-        const whatToRemove: string[] = info.config.remove || ['caller'];
+  function create(info: ts.server.PluginCreateInfo) {
+    // Get a list of things to remove from the completion list from the config object.
+    // If nothing was specified, we'll just remove 'caller'
+    const whatToRemove: string[] = info.config.remove || ["caller"];
 
-        // Diagnostic logging
-        info.project.projectService.logger.info("I'm getting set up now! Check the log for this message.");
+    // Diagnostic logging
+    info.project.projectService.logger.info(
+      "I'm getting set up now! Check the log for this message."
+    );
 
-        // Set up decorator
-        const proxy: ts.LanguageService = Object.create(null);        
-        for (let k of Object.keys(info.languageService) as Array<keyof ts.LanguageService>) {
-            const x = info.languageService[k];
-            proxy[k] = (...args: Array<{}>) => x.apply(info.languageService, args);
-        }
-
-        // Remove specified entries from completion list
-        proxy.getCompletionsAtPosition = (fileName, position) => {
-            const prior = info.languageService.getCompletionsAtPosition(fileName, position);
-            const oldLength = prior.entries.length;
-            prior.entries = prior.entries.filter(e => whatToRemove.indexOf(e.name) < 0);
-
-            // Sample logging for diagnostic purposes
-            if (oldLength !== prior.entries.length) {
-                info.project.projectService.logger.info(`Removed ${oldLength - prior.entries.length} entries from the completion list`);
-            }
-
-            return prior;
-        };
-
-        return proxy;
+    // Set up decorator
+    const proxy: ts.LanguageService = Object.create(null);
+    for (let k of Object.keys(info.languageService) as Array<
+      keyof ts.LanguageService
+    >) {
+      const x = info.languageService[k];
+      proxy[k] = (...args: Array<{}>) => x.apply(info.languageService, args);
     }
 
-    return { create };
+    // Remove specified entries from completion list
+    proxy.getCompletionsAtPosition = (fileName, position) => {
+      const prior = info.languageService.getCompletionsAtPosition(
+        fileName,
+        position
+      );
+      const oldLength = prior.entries.length;
+      prior.entries = prior.entries.filter(e => whatToRemove.indexOf(e.name) < 0);
+
+      // Sample logging for diagnostic purposes
+      if (oldLength !== prior.entries.length) {
+        const entriesRemoved = oldLength - prior.entries.length;
+        info.project.projectService.logger.info(
+          `Removed ${entriesRemoved} entries from the completion list`
+        );
+      }
+
+      return prior;
+    };
+
+    return proxy;
+  }
+
+  return { create };
 }
 
 export = init;


### PR DESCRIPTION
Max-width is set to 84, since that is what github pages can handle best.

See: https://github.com/Microsoft/TypeScript-wiki/issues/176

I mostly did the new relevant docs and also deleted trailing spaces (vscode did that for me, hope that's okay).