### PR TITLE
Add html element example

### DIFF
--- a/JSDoc-support-in-JavaScript.md
+++ b/JSDoc-support-in-JavaScript.md
@@ -63,6 +63,14 @@ var var8;
 /** @type {{a: string, b: number}} */
 var var9;
 
+// You can specify as an HTML Element
+
+// An element with dom properties
+/** @type {HTMLElement} myElement */
+var myElement = document.querySelector(selector);
+element.dataset.myData = '';
+
+
 // "@typedef" may be used to define complex types
 // (this same same syntax works with @param)
 /**


### PR DESCRIPTION
The default `Element` type shows errors for common dom attributes. This PR adds a doc for declaring an explicit `HTMLElement` type.