### PR TITLE
fix jsdoc @typedef annotation order error

### DIFF
--- a/JSDoc-support-in-JavaScript.md
+++ b/JSDoc-support-in-JavaScript.md
@@ -156,7 +156,7 @@ import types can also be used in type alias declarations:
 
 ```js
 /**
- * @typedef Pet { import("./a").Pet }
+ * @typedef { import("./a").Pet } Pet
  */
 
 /**


### PR DESCRIPTION
![codepen](https://ws2.sinaimg.cn/large/006tKfTcgy1g1g7gj4sssj31bi0b6q53.jpg)

Here shows the right syntax and mis-spelled version