### PR TITLE
docs(jsdoc): Document unsupported JSDoc tags with open issues

### DIFF
--- a/JSDoc-support-in-JavaScript.md
+++ b/JSDoc-support-in-JavaScript.md
@@ -519,3 +519,16 @@ var normal;
 Unlike JSDoc's type system, Typescript only allows you to mark types as containing null or not.
 There is no explicit non-nullability -- if strictNullChecks is on, then `number` is not nullable.
 If it is off, then `number` is nullable.
+
+### Unsupported tags
+
+TypeScript ignores any unsupported JSDoc tags.
+
+The following tags have open issues to support them:
+
+- `@const` ([issue #19672](https://github.com/Microsoft/TypeScript/issues/19672))
+- `@inheritdoc` ([issue #23215](https://github.com/Microsoft/TypeScript/issues/23215))
+- `@memberof` ([issue #7237](https://github.com/Microsoft/TypeScript/issues/7237))
+- `@readonly` ([issue #17233](https://github.com/Microsoft/TypeScript/issues/17233))
+- `@yields` ([issue #23857](https://github.com/Microsoft/TypeScript/issues/23857))
+- `{@link …}` ([issue #16498](https://github.com/Microsoft/TypeScript/issues/16498))


### PR DESCRIPTION
Opened on request of @brettz9 in https://github.com/jsdoctypeparser/jsdoctypeparser/issues/50#issuecomment-480556815.

See also https://github.com/Microsoft/TypeScript/issues/7237

review?(@sandersn)