### PR TITLE
Fixed broken link for JSDoc support.

### DIFF
--- a/JavaScript-Language-Service-in-Visual-Studio.md
+++ b/JavaScript-Language-Service-in-Visual-Studio.md
@@ -4,9 +4,9 @@ Visual Studio 2017 provides a powerful JavaScript editing experience right out o
 
 >  The JavaScript language service in Visual Studio 2017 uses a new engine for the language service (former code name "Salsa"). Details are included here in this topic, and you might also want to read this [blog post](https://blogs.msdn.microsoft.com/visualstudio/2016/11/28/more-productive-javascript-in-visual-studio-2017-rc/). The new editing experience also mostly applies in VS Code. See the [VS Code docs](https://code.visualstudio.com/docs/languages/javascript) for more info.
 
-For more information about the general IntelliSense functionality of Visual Studio, see [Using IntelliSense](https://docs.microsoft.com/en-us/visualstudio/ide/using-intellisense). 
+For more information about the general IntelliSense functionality of Visual Studio, see [Using IntelliSense](https://docs.microsoft.com/en-us/visualstudio/ide/using-intellisense).
 
-## What's New in the JavaScript language service in Visual Studio 2017 
+## What's New in the JavaScript language service in Visual Studio 2017
 - [Richer IntelliSense](#Rich)
 - [Automatic acquisition of type definitions](#Auto)
 - [Support for ES6 and beyond](#ES6)
@@ -21,11 +21,11 @@ TypeScript uses several sources to build up this information.
 - [IntelliSense based on TypeScript Declaration Files](#TSDeclFiles)
 
 #### <a name="TypeInference"></a>IntelliSense based on type inference
-In JavaScript, most of the time there is no explicit type information available. 
+In JavaScript, most of the time there is no explicit type information available.
 Luckily, it is usually fairly easy to deduce a type given the surrounding code context.
 This process is called type inference.
 
-For a variable or property, the type is typically the type of the value used to initialize it or the most recent value assignment. 
+For a variable or property, the type is typically the type of the value used to initialize it or the most recent value assignment.
 
 ```js
 var nextItem = 10;
@@ -35,7 +35,7 @@ nextItem = "box";
 nextItem; // now we know nextItem is a string
 ```
 
-For a function, the return type can be inferred from the return statements. 
+For a function, the return type can be inferred from the return statements.
 
 For function parameters, there is currently no inference, but there are ways to work around this using JSDoc or TypeScript `.d.ts` files (see later sections).
 
@@ -70,7 +70,7 @@ x.b = false;
 x. // <- "x" is shown as having properties a, b, and c of the types specified
 ```
 
-As mentioned, function parameters are never inferred. However, using the JSDoc `@param` tag you can add types to function parameters as well. 
+As mentioned, function parameters are never inferred. However, using the JSDoc `@param` tag you can add types to function parameters as well.
 
 ```js
 /**
@@ -80,8 +80,8 @@ function Foo(param1) {
     this.prop = param1; // "param1" (and thus "this.prop") are now of type "string".
 }
 ```
- 
-See [this doc](https://github.com/Microsoft/TypeScript/wiki/JsDoc-support-in-JavaScript) for the JsDoc annotations currently supported.
+
+See [this doc](https://github.com/microsoft/TypeScript-wiki/blob/master/JSDoc-support-in-JavaScript.md) for the JsDoc annotations currently supported.
 
 #### <a name="TsDeclFiles"></a> IntelliSense based on TypeScript Declaration Files
 
@@ -96,11 +96,11 @@ _**TypeScript declarations used in JavaScript**_
 ## <a name="Auto"></a> Automatic acquisition of type definitions
 In the TypeScript world, most popular JavaScript libraries have their APIs described by `.d.ts` files, and the most common repository for such definitions is on [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).
 
-By default, the Salsa language service will try to detect which JavaScript libraries are in use and automatically download and reference the corresponding `.d.ts` file that describes the library in order to provide richer IntelliSense. The files are downloaded to a cache located under the user folder at `%LOCALAPPDATA%\Microsoft\TypeScript`. 
+By default, the Salsa language service will try to detect which JavaScript libraries are in use and automatically download and reference the corresponding `.d.ts` file that describes the library in order to provide richer IntelliSense. The files are downloaded to a cache located under the user folder at `%LOCALAPPDATA%\Microsoft\TypeScript`.
 
 > This feature is **disabled** by default if using a `tsconfig.json` configuration file, but may be set to enabled as outlined further below).
 
-Currently auto-detection works for dependencies downloaded from npm (by reading the `package.json` file), Bower (by reading the `bower.json` file), and for loose files in your project that match a list of roughly the top 400 most popular JavaScript libraries. For example, if you have `jquery-1.10.min.js` in your project, the file `jquery.d.ts` will be fetched and loaded in order to provide a better editing experience. This `.d.ts` file will have no impact on your project. 
+Currently auto-detection works for dependencies downloaded from npm (by reading the `package.json` file), Bower (by reading the `bower.json` file), and for loose files in your project that match a list of roughly the top 400 most popular JavaScript libraries. For example, if you have `jquery-1.10.min.js` in your project, the file `jquery.d.ts` will be fetched and loaded in order to provide a better editing experience. This `.d.ts` file will have no impact on your project.
 
 If you do not wish to use auto-acquisition, disable it by adding a configuration file as outlined below. You can still place definition files for use directly within your project manually.
 
@@ -118,7 +118,7 @@ The required settings for the tsconfig file are outlined below:
 By default this is `false`, as TypeScript compiles to JavaScript, and this is necessary to avoid the compiler including files it just compiled.
  - `outDir`: This should be set to a location not included in the project, in order that the emitted JavaScript files are not detected and then included in the project (see `exclude` below).
  - `module`: If using modules, this setting tells the compiler which module format the emitted code should use (e.g. `commonjs` for Node or bundlers such as Browserify).
- - `exclude`: This setting states which folders not to include in the project. 
+ - `exclude`: This setting states which folders not to include in the project.
  The output location, as well as non-project folders such as `node_modules` or `temp`, should be added to this setting.
  - `enableAutoDiscovery`: This setting enables the automatic detection and download of definition files as outlined above.
  - `compileOnSave`: This setting tells the compiler if it should recompile any time a source file is saved in Visual Studio.
@@ -181,7 +181,7 @@ exports.default = Subscription_1.Subscription;
 
 ## <a name="JSX"></a> JSX syntax support
 
-JavaScript in Visual Studio 2017 has rich support for the JSX syntax. JSX is a syntax set that allows HTML tags within JavaScript files. 
+JavaScript in Visual Studio 2017 has rich support for the JSX syntax. JSX is a syntax set that allows HTML tags within JavaScript files.
 
 The illustration below shows a React component defined in the `comps.tsx` TypeScript file, and then this component being used from the `app.jsx` file, complete with IntelliSense for completions and documentation within the JSX expressions.
 You don't need TypeScript here, this specific example just happens to contain some TypeScript code as well.
@@ -198,7 +198,7 @@ var comps_1 = require('./comps');
 var x = React.createElement(comps_1.RepoDisplay, {description: "test"});
 ```
 
-## Notable Changes from VS 2015 
+## Notable Changes from VS 2015
 As Salsa is a completely new language service, there are a few behaviors that will be different or absent from the previous experience.
 The most notable of these changes are the replacement of VSDoc with JSDoc, the removal of custom `.intellisense.js` extensions, and limited IntelliSense for specific code patterns.
 
@@ -219,7 +219,7 @@ You can learn more about declaration (`.d.ts`) file authoring [here](http://www.
 
 ### Unsupported patterns
 Because the new language service is powered by static analysis rather than an execution engine (read [this issue](https://github.com/Microsoft/TypeScript/issues/4789) for information of the differences), there are a few JavaScript patterns that no longer can be detected.
-The most common pattern is the "expando" pattern. 
+The most common pattern is the "expando" pattern.
 Currently the language service cannot provide IntelliSense on objects that have properties tacked on after declaration.
 For example:
 


### PR DESCRIPTION
1. The link for JSDoc support was directing the user to an empty page. Fixed.