### PR TITLE
Fix incorrect code sample in "Things that don't work" section of FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1188,8 +1188,9 @@ It creates a *single* private field that all classes share:
 var a = new Foo();
 a.increment(); // Prints 1
 a.increment(); // Prints 2
-var b = new Foo(); // Should not affect a
-a.increment(); // Prints 1
+var b = new Foo(); // increments on b should be independent of a 
+b.increment(); // Supposed to print 1, prints 3
+a.increment(); // Should print 3, prints 4
 ```
 
 ### You should emit classes like this so they don't lose `this` in callbacks


### PR DESCRIPTION
The code sample in [you should emit classes like this so they have real private members FAQ](https://github.com/microsoft/TypeScript/wiki/FAQ#you-should-emit-classes-like-this-so-they-have-real-private-members) is incorrect, it "shows" that instantiating a new `Foo()` would reset the private `x` of `a` which is not True, in fact that is not what happens:

```
> var Foo = (function () {
...     var x = 0;
...
...     function Foo() {
...     }
...     Foo.prototype.increment = function () {
...         x++;
...         return x;
...     };
...     return Foo;
... })();
undefined
> var a = new Foo();
undefined
> a.increment();
1
> a.increment();
2
> var b = new Foo();
undefined
> a.increment();
3
```

But it is true that `a` and `b` use the same `x` and therefore one influences the other. I've changed the code example with a correct one that still highlights the problem.