### PR TITLE
Change type in request example

### DIFF
--- a/Standalone-Server-(tsserver).md
+++ b/Standalone-Server-(tsserver).md
@@ -20,7 +20,7 @@ ls node_modules\typescript\lib\tsserver.js
 Requests are JSON following the protocol definition. Here is an example request to open a file `c:/DefinitelyTyped/gregorian-calendar/index.d.ts`:
 
 ```js
-{"seq":1,"type":"quickinfo","command":"open","arguments":{"file":"c:/DefinitelyTyped/gregorian-calendar/index.d.ts"}}
+{"seq":1,"type":"request","command":"open","arguments":{"file":"c:/DefinitelyTyped/gregorian-calendar/index.d.ts"}}
 ```
 
 Responses are augmented JSON format. the Message stars with a header with the content length followed by a line separator (`\r\n`) followed by the response body as a JSON string:


### PR DESCRIPTION
Tiny docs change to avoid confusion.  `tsserver` doesn't seem to mind this bad example as it defers to the command.