### PR TITLE
Updated Roadmap (markdown)

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -11,7 +11,6 @@ This page outlines specific features and fixes that are scheduled or planned for
 * Investigate [nominal typing support](https://github.com/Microsoft/TypeScript/issues/202)
 * [Flattening declarations](https://github.com/Microsoft/TypeScript/issues/4433)
 * Implement ES Decorator proposal
-* Implement ES Private Fields
 * Investigate [Ambient](https://github.com/Microsoft/TypeScript/issues/2900), [Deprecated](https://github.com/Microsoft/TypeScript/issues/390), and [Conditional](https://github.com/Microsoft/TypeScript/issues/3538) decorators
 * [Investigate partial type argument inference](https://github.com/Microsoft/TypeScript/pull/26349)
 * Quick fix to [Scaffold local `@types` packages](https://github.com/Microsoft/TypeScript/issues/25746)


### PR DESCRIPTION
**ES Private Fields** are now supported in TypeScript 3.8 and can be removed from Future list