### PR TITLE
Fix non-complete implementation of a language service

### DIFF
--- a/Using-the-Compiler-API.md
+++ b/Using-the-Compiler-API.md
@@ -397,7 +397,9 @@ function watch(rootFileNames: string[], options: ts.CompilerOptions) {
     getDefaultLibFileName: options => ts.getDefaultLibFilePath(options),
     fileExists: ts.sys.fileExists,
     readFile: ts.sys.readFile,
-    readDirectory: ts.sys.readDirectory
+    readDirectory: ts.sys.readDirectory,
+    directoryExists: ts.sys.directoryExists,
+    getDirectories: ts.sys.getDirectories,
   };
 
   // Create the language service files


### PR DESCRIPTION
The implementation of a LanguageServiceHost in the example is missing `directoryExists` and `getDirectories` methods which are crucial for the resolving `typeRoots` automatically in the function `ts.getAutomaticTypeDirectiveNames`.