### PR TITLE
Getting the DTS from a JavaScript file example should replace .js to …

### DIFF
--- a/Using-the-Compiler-API.md
+++ b/Using-the-Compiler-API.md
@@ -106,7 +106,7 @@ function compile(fileNames: string[], options: ts.CompilerOptions): void {
     console.log(host.readFile(file))
 
     console.log("### Type Definition\n")
-    const dts = file.replace(".ts", ".d.ts")
+    const dts = file.replace(".js", ".d.ts")
     console.log(createdFiles[dts])
   })
 }


### PR DESCRIPTION
Getting the DTS from a JavaScript file example should replace .js to .d.ts