### PR TITLE
Add target mapping for Node.js 14

### DIFF
--- a/Node-Target-Mapping.md
+++ b/Node-Target-Mapping.md
@@ -5,6 +5,18 @@ for ECMAScript features are available in your node version.
 
 To update this file, you can use [node.green](https://node.green) to map to the different options in [microsoft/typescript@src/lib](https://github.com/Microsoft/TypeScript/tree/master/src/lib)
 
+#### Node 14
+
+```json
+{
+  "compilerOptions": {
+    "lib": ["ES2020"],
+    "module": "commonjs",
+    "target": "ES2020"
+  }
+}
+```
+
 #### Node 12
 
 ```json


### PR DESCRIPTION
According to [node.green](https://node.green/), Node.js 14 has full support for ES2020

Closes #261 