### PR TITLE
Fix typo in Useful-Links-for-TypeScript-Issue-Management.md

### DIFF
--- a/Useful-Links-for-TypeScript-Issue-Management.md
+++ b/Useful-Links-for-TypeScript-Issue-Management.md
@@ -10,4 +10,4 @@
  * [Design Meeting Docket](https://github.com/Microsoft/TypeScript/issues?q=is%3Aopen+is%3Aissue+label%3A%22in+discussion%22): Open `Suggestion` issues tagged with `In Discussion`
 
  * [Needs Proposal Review](https://github.com/Microsoft/TypeScript/issues?q=is%3Aopen+is%3Aissue+label%3A%22needs+proposal%22): Open `Suggestion` issues tagged with `Needs Proposal`
- * [Needs More Info Review](https://github.com/Microsoft/TypeScript/issues?q=is%3Aopen+is%3Aissue+label%3A%22needs+more+info%22): Open `Suggestion` issues tagged with `Needs Proposal`
+ * [Needs More Info Review](https://github.com/Microsoft/TypeScript/issues?q=is%3Aopen+is%3Aissue+label%3A%22needs+more+info%22): Open `Suggestion` issues tagged with `Needs More Info`


### PR DESCRIPTION
The `Needs More Info Review` link was incorrectly described as "issues tagged with `Needs Proposal`".