### PR TITLE
Note `tsc` doesn't use language service plugins

### DIFF
--- a/Writing-a-Language-Service-Plugin.md
+++ b/Writing-a-Language-Service-Plugin.md
@@ -4,7 +4,7 @@ In TypeScript 2.2 and later, developers can enable *language service plugins* to
 
 ## What's a Language Service Plugin?
 
-TypeScript Language Service Plugins ("plugins") are for changing the *editing experience* only. The core TypeScript language remains the same. Plugins can't add new language features such as new syntax or different typechecking behavior, and plugins aren't loaded during normal commandline typechecking or emitting.
+TypeScript Language Service Plugins ("plugins") are for changing the *editing experience* only. The core TypeScript language remains the same. Plugins can't add new language features such as new syntax or different typechecking behavior, and plugins aren't loaded during normal commandline typechecking or emitting, (so are not loaded by `tsc`).
 
 Instead, plugins are for augmenting the editing experience. Some examples of things plugins might do:
  * Provide errors from a linter inline in the editor


### PR DESCRIPTION
Clarify the documentation on language service plugins for users who are unfamiliar with the fact that the typescript language service is not used by the `tsc` command.

Another case of confusion on this point: https://github.com/microsoft/TypeScript/issues/34548