### PR TITLE
Implement a two-way mirroring between the wiki and its public repo

### DIFF
--- a/.github/workflows/sync
+++ b/.github/workflows/sync
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -ue
+shopt -s extglob
+
+PUSHER="${PUSHER// +( )/ }"; PUSHER="${PUSHER# }"; PUSHER="${PUSHER% }"
+NAME="${PUSHER% <*}"
+EMAIL="${PUSHER##* <}"; EMAIL="${EMAIL%>}"
+echo "Setting git username to \"$NAME\" and email to \"$EMAIL\""
+export GIT_AUTHOR_NAME="$NAME"
+export GIT_AUTHOR_EMAIL="$EMAIL"
+export GIT_COMMITTER_NAME="$NAME"
+export GIT_COMMITTER_EMAIL="$EMAIL"
+
+DASHREMOTE="$(git remote get-url origin)"
+DOTREMOTE="${DASHREMOTE//-wiki/.wiki}"
+echo "\$DASHREMOTE = $DASHREMOTE, \$DOTREMOTE = $DOTREMOTE"
+
+for r in "$DASHREMOTE" "$DOTREMOTE"; do
+  if [[ "$(git ls-remote --symref "$r" HEAD | grep "^ref:")" \
+          != $'ref: refs/heads/master\tHEAD' ]]; then
+    echo "Unexpected branch name at $r: expected to see \"master\""
+  fi
+done
+
+echo ">>> Adding DOTREMOTE"
+git remote add dot "$DOTREMOTE"
+git fetch dot
+
+echo ">>> Merging changes"
+git pull --no-edit --no-rebase dot "master"
+
+echo ">>> Pushing merges"
+git push origin
+git push dot

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,39 +1,27 @@
-# Based on https://www.growingwiththeweb.com/2016/07/enabling-pull-requests-on-github-wikis.html
+# Roughly based on
+#   https://www.growingwiththeweb.com/2016/07/enabling-pull-requests-on-github-wikis.html
+
 name: Sync Two Wiki Repos
 
 on:
-  # Merged PRs
-  push:
-    branches: [master]
-  # Weekly
-  schedule:
-    # https://crontab.guru/#0_12_*_*_1
-    - cron: "0 12 * * 1"
-  # Whenever someone asks
-  workflow_dispatch:
+  push: {branches: [master]}
+  schedule: [{cron: "7 0 * * 1,3"}] # https://crontab.guru/#7_0_*_*_1,3
+  workflow_dispatch:                # on request
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-
-        # Setup Git
-      - run: git config user.name "typescript-bot"
-      - run: git config user.email "bot@typescriptlang.org"
-
-        # Replace remotes with auth'd versions, then pull the .wiki version (the one people can't PR to)
-        # then merge in any changes from here and push
-      - 
-        run: |
-          git remote remove origin
-          git remote add origin https://$GITHUB_TOKEN@github.com/microsoft/TypeScript-wiki.git
-          git remote add upstream https://$GITHUB_TOKEN@github.com/microsoft/TypeScript.wiki.git
-          git fetch origin
-          git fetch upstream
-          git merge upstream/master --no-edit 
-          git push origin HEAD:master
-          git push upstream HEAD:master
-        env:
-          GITHUB_TOKEN: ${{ secrets.TS_BOT_TOKEN }}
-
+    - name: Get repo name
+      run: R=${GITHUB_REPOSITORY%?wiki}; echo "BASENAME=${R##*/}" >> $GITHUB_ENV
+    - name: Checkout ${{ env.BASENAME }}-wiki
+      uses: actions/checkout@v2
+      with:
+        repository: "${{ GITHUB.repository_owner }}/${{ env.BASENAME }}-wiki"
+        token: ${{ secrets.TS_BOT_TOKEN }}
+        fetch-depth: 0
+    - name: Run sync
+      run: ./.github/workflows/sync
+      env:
+        PUSHER: typescript-bot <bot@typescriptlang.org>
+        AUTH: ${{ secrets.TS_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## The TypeScript wiki
 
-This repo is the source of truth for the GitHub wiki, PRs to this repo are automatically merged into the 
-auto-generated GitHub [repo for the wiki](https://github.com/microsoft/TypeScript/wiki). This is done 
-in a GitHub Action in [`.github/workflows/sync.yml`](.github/workflows/sync.yml).
+This repo is a mirror of [the TypeScript wiki](https://github.com/Microsoft/TypeScript/wiki).
+Changes on either the wiki or this repo are immediately mirrored to the other side.
+This is done in a GitHub Action [here](.github/workflows/sync.yml), and [another](https://github.com/microsoft/TypeScript/blob/master/.github/workflows/ci.yml) in the TS repo.
 
 The wiki root is [Home.md](./Home.md).
 


### PR DESCRIPTION
> See also the [TS side](https://github.com/microsoft/TypeScript/pull/44207) of this PR.

Previously, changes to the wiki would get merged to the public repo in a
once-a-week action.  This significantly revises this, making the two
sides be mirrors (up to the few seconds it takes to do a merge).

This is driven by a minimal-ish yaml file in both sides (`TypeScript`
and `TypeScript-wiki`) that *always* works from the script in the public
repo.

The two action specs are nearly identical, but there are some differences:

  - On the main repo, trigger on a `gollum` event, and in the wiki repo
    the usual (pushes, schedule, manual).  (The schedule run is kept as
    a just-in-case, and it's now running twice a week.)
  - The filename is `sync-wiki` on the TS side and just `sync` in the
    wiki.  (Good to avoid confusion if both files somehow find
    themselves in the same neighborhood.)
  - The secret names are different since I used the name that already
    exists in each side.

The script does *not* start with a checkout of its repository.  Doing
this in the TS side would be redundant (it would get the TS tree) and
slow.  Instead, it's always cloning the public wiki repo (`DASHREMOTE`,
since its url is `.../TypeScript-wiki`) and then fetching into it the
repo of the rendered wiki (`DOTREMOTE`, with a `.../TypeScript.wiki`)
url.

Also revised the README, since they should always be mirrored with this
change, and therefore there is no "source of truth".