### PR TITLE
Add target mapping for Node.js 16

### DIFF
--- a/Node-Target-Mapping.md
+++ b/Node-Target-Mapping.md
@@ -5,6 +5,18 @@ for ECMAScript features are available in your node version.
 
 To update this file, you can use [node.green](https://node.green) to map to the different options in [microsoft/typescript@src/lib](https://github.com/Microsoft/TypeScript/tree/main/src/lib)
 
+#### Node 16
+
+```json
+{
+  "compilerOptions": {
+    "lib": ["ES2021"],
+    "module": "commonjs",
+    "target": "ES2021"
+  }
+}
+```
+
 #### Node 14
 
 ```json


### PR DESCRIPTION
Node.js 16 is LTS, but we don't have mapping at the wiki. This pull request should resolve this issue.