### PR TITLE
Add language service plugin reference

### DIFF
--- a/Writing-a-Language-Service-Plugin.md
+++ b/Writing-a-Language-Service-Plugin.md
@@ -251,3 +251,4 @@ Some other TypeScript Language Service Plugin implementations you can look at fo
 * https://github.com/angelozerr/tslint-language-service/
 * https://github.com/xialvjun/ts-sql-plugin
 * https://github.com/HearTao/ts-string-literal-enum-plugin
+* https://github.com/ngnijland/typescript-todo-or-die-plugin


### PR DESCRIPTION
Please allow me to add our language service plugin to the in the references section of the "Writing a Language Service Plugin" page.