### PR TITLE
Improve writing a language service plugin

### DIFF
--- a/Writing-a-Language-Service-Plugin.md
+++ b/Writing-a-Language-Service-Plugin.md
@@ -49,14 +49,20 @@ function init(modules: { typescript: typeof import("typescript/lib/tsserverlibra
   function create(info: ts.server.PluginCreateInfo) {
     // Set up decorator object
     const proxy: ts.LanguageService = Object.create(null);
+
     for (let k of Object.keys(info.languageService) as Array<keyof ts.LanguageService>) {
       const x = info.languageService[k]!;
       // @ts-expect-error - JS runtime trickery which is tricky to type tersely
       proxy[k] = (...args: Array<{}>) => x.apply(info.languageService, args);
     }
-    return { create };
+
+    return proxy;
   }
+
+  return { create };
 }
+
+export = init;
 ```
 
 This sets up a "pass-through" decorator that invokes the underlying language service for all methods.

--- a/Writing-a-Language-Service-Plugin.md
+++ b/Writing-a-Language-Service-Plugin.md
@@ -108,6 +108,7 @@ function create(info: ts.server.PluginCreateInfo) {
   // If nothing was specified, we'll just remove 'caller'
   const whatToRemove: string[] = info.config.remove || ["caller"];
 
+  const proxy: ts.LanguageService = Object.create(null);
   // ... (set up decorator here) ...
 
   // Remove specified entries from completion list
@@ -120,6 +121,8 @@ function create(info: ts.server.PluginCreateInfo) {
     prior.entries = prior.entries.filter(e => whatToRemove.indexOf(e.name) < 0);
     return prior;
   };
+
+  return proxy;
 }
 ```
 


### PR DESCRIPTION
While creating our Language Service plugin we used this article as our main source. It was a huge help. Here are a few improvements so it can be of an even better help for the next person using it.

This PR does two small changes:

**Fix the "Decorator Creation" code example**

- Return `create` to the factory function instead to itself
- Return `proxy` to the `create` function
- Add `export = init;` to the end of the example

**Add a bit more context to the "Handling User Configuration" code example**

The combination of the bug in the "Decorator Creation" code example and this code example was confusing us. I think a little extra context will help the next person reading this.