### PR TITLE
Inform about `useDefineForClassFields` breaking change in TS >=4.3

### DIFF
--- a/Breaking-Changes.md
+++ b/Breaking-Changes.md
@@ -249,6 +249,52 @@ enum E {
 
 For more details, [see the original change](https://github.com/microsoft/TypeScript/pull/42472)
 
+## Class fields while extending classes
+
+TypeScript 4.3 introduces new `useDefineForClassFields` compiler option, which defaults to `true`.
+
+The class' fields initialization will be included then.
+
+```ts
+class Example {
+    private abc: string;
+}
+```
+
+Becomes:
+
+```js
+// TypeScript <4.3 or "useDefineForClassFields": false
+class Example {
+}
+
+// TypeScript >=4.3 default behavior - "useDefineForClassFields": true
+class Example {
+    abc;
+}
+```
+
+It may introduce the problem when extending classes - after `super` constructor will be called, all child class properties will be reinitialized.
+It may lead to unexpected behavior, where the value was set during super class constructor, but it's reset later.
+
+```ts
+class Parent {
+    public value: string | null;
+
+    public constructor() {
+        this.value = "test value";
+    }
+}
+
+class Child extends Parent {
+    public value!: string;
+}
+
+console.log(new Child().value);
+// for `useDefineForClassFields: false` -> "test value"
+// for `useDefineForClassFields: true`  -> undefined
+```
+
 # TypeScript 4.2
 
 ## `noImplicitAny` Errors Apply to Loose `yield` Expressions


### PR DESCRIPTION
While I've been upgrading the TypeScript, I encountered multiple strange issues, related to abstract classes. It took me a while to detect what was the problems reason, as I haven't found in any notes information about `useDefineForClassFields` option.

It's changing the default behaviour, which may easily break the existing code. I added simplest example as possible in this PR, as I felt that my specific example may be *too specific*, while this simplified example may help to identify issue anyway.

The exact problem I encountered:

```ts
abstract class Parent {
    public constructor() {
        this.run();
    }

    protected abstract run(): void;
}

class Child extends Parent {
    public value!: string;

    protected override run() {
        this.value = "test value";
    }
}

console.log(new Child().value);
// for `useDefineForClassFields: false` -> "test value"
// for `useDefineForClassFields: true`  -> undefined
```

Took me a while to detect the culprit, so I think that it's worth to add information about that to documentation, so it will reduce problems with migration.