### PR TITLE
Fix Performance dropdown closing </details> tag

### DIFF
--- a/Performance.md
+++ b/Performance.md
@@ -149,7 +149,7 @@ This involved:
 
 For a very big project, this might happen over and over and over again per a module.
 
-</summary>
+</details>
 
 ## Preferring Base Types Over Unions
 


### PR DESCRIPTION
Presently a large portion of the Performance document is concealed in a collapsible section due to an unclosed `<details>` tag.

[`details` in GitHub MarkDown](https://gist.github.com/ericclemmons/b146fe5da72ca1f706b2ef72a20ac39d)

## Current

![ts-wiki-perf-bug](https://user-images.githubusercontent.com/31659809/190442333-d37a4e83-0003-4b59-a134-daa01f21e560.gif)


## With Fix

![ts-wiki-perf-fix](https://user-images.githubusercontent.com/31659809/190442748-85034d8a-aa63-43be-9df7-0e6fa34ec4ba.gif)

