### PR TITLE
Remove "current" from 2021 Roadmap

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,6 +1,6 @@
 This page outlines specific features and fixes that are scheduled or planned for given releases. The 6-month roadmaps that outlines focus areas of work can be viewed for
 
-* [January to June 2021](https://github.com/microsoft/TypeScript/issues/42673) (current)
+* [January to June 2021](https://github.com/microsoft/TypeScript/issues/42673)
 * [January to December 2020](https://github.com/microsoft/TypeScript/issues/36948)
 * [July to December 2019](https://github.com/microsoft/TypeScript/issues/33118)
 * [January to June 2019](https://github.com/Microsoft/TypeScript/issues/29288)


### PR DESCRIPTION
Remove the outdated "current" mark from the January to June 2021 Roadmap link.