### PR TITLE
Mention Discriminated Unions

### DIFF
--- a/Performance.md
+++ b/Performance.md
@@ -180,7 +180,7 @@ For a two-element union, this is trivial and inexpensive.
 However, if your union has more than a dozen elements, it can cause real problems in compilation speed.
 For instance, to eliminate redundant members from a union, the elements have to be compared pairwise, which is quadratic.
 This sort of check might occur when intersecting large unions, where intersecting over each union member can result in enormous types that then need to be reduced.
-One way to avoid this is to use subtypes, rather than unions.
+One way to avoid this is to employ base types and [discriminate unions](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#discriminated-unions).
 
 ```ts
 interface Schedule {


### PR DESCRIPTION
The `day` property is being used as a discriminator to distinguish between `WeekdaySchedule` and `WeekendSchedule`, which is why I want to highlight the concept of [discriminated unions](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#discriminated-unions).