### PR TITLE
FAQ: Remove suggestion to comment on closed & locked issues

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -113,7 +113,7 @@ Here are some behaviors that may look like bugs, but aren't.
 > I want to request one of the following features...
 
 Here's a list of common feature requests and their corresponding issue.
-Please leave comments in these rather than logging new issues.
+Please read and consider the prior discussion before logging new issues with similar proposals/requests.
 * Safe navigation operator, AKA CoffeeScript's null conditional/propagating/propagation operator, AKA C#'s' `?.` operator [#16](https://github.com/Microsoft/TypeScript/issues/16)
 * Minification [#8](https://github.com/Microsoft/TypeScript/issues/8)
 * Extension methods [#9](https://github.com/Microsoft/TypeScript/issues/9)


### PR DESCRIPTION
The FAQ's §[Common Feature Requests](https://github.com/microsoft/TypeScript-wiki/blob/main/FAQ.md#common-feature-requests) opens:
> Here's a list of common feature requests and their corresponding issue. Please leave comments in these rather than logging new issues.

The only problem is, the majority of those issues (and the ones they link to, in the case of aggregate/tracking issues) have been bot-locked, so users _can't_ leave comments there.

This PR rewrites the second sentence to encourage simply _reading_, rather than commenting on, the closed/locked issues.