### PR TITLE
Set Node 18 back to ES2022 lib

### DIFF
--- a/Node-Target-Mapping.md
+++ b/Node-Target-Mapping.md
@@ -24,14 +24,12 @@ To update this file, you can use [node.green](https://node.green) to map to the 
 ```json
 {
   "compilerOptions": {
-    "lib": ["ES2023"],
+    "lib": ["ES2022"],
     "module": "node16",
     "target": "ES2022"
   }
 }
 ```
-
-Note: All versions of Node 18 support all ES2023 runtime features, so `lib` can be safely set to `ES2023`.
 
 #### Node 16
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/60965