### PR TITLE
`--enforceReadonly` has not yet been released

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -460,7 +460,7 @@ This flag affects *all* optional properties and there is no mechanism for doing 
 
 ### Enforce `readonly` in Subtyping / Assignability
 
-Enable `--enforceReadonly` (available in TypeScript 5.6; see [#58296](https://github.com/microsoft/TypeScript/pull/58296))
+Enable `--enforceReadonly` (not yet released; see [#58296](https://github.com/microsoft/TypeScript/pull/58296))
 
 ## Common Comments
 


### PR DESCRIPTION
As suggested by https://github.com/microsoft/TypeScript/pull/58296#issuecomment-2617028921.